### PR TITLE
Create image verification portal #8

### DIFF
--- a/imaginate_api/app.py
+++ b/imaginate_api/app.py
@@ -4,6 +4,9 @@ from imaginate_api.date.routes import bp as date_routes
 from imaginate_api.image.routes import bp as image_routes
 from imaginate_api.config import Config
 
+# Constants
+from schemas.image_info import ImageStatus
+
 
 def create_app():
   app = Flask(__name__)

--- a/imaginate_api/app.py
+++ b/imaginate_api/app.py
@@ -4,10 +4,6 @@ from imaginate_api.date.routes import bp as date_routes
 from imaginate_api.image.routes import bp as image_routes
 from imaginate_api.config import Config
 
-# Constants
-from schemas.image_info import ImageStatus
-
-
 def create_app():
   app = Flask(__name__)
   app.config.from_object(Config)

--- a/imaginate_api/image/routes.py
+++ b/imaginate_api/image/routes.py
@@ -119,7 +119,7 @@ def update_status():
         return "new status not recieved",400  
     return "status updated",200
 
-@bp.route("/delete_rejected", methods=["DELETE"])
+@bp.route("/delete-rejected", methods=["DELETE"])
 def delete_rejected():
     filter = {"status":"rejected"}
     results = db["fs.files"].delete_many(filter)

--- a/imaginate_api/image/routes.py
+++ b/imaginate_api/image/routes.py
@@ -1,5 +1,7 @@
-from flask import Blueprint, jsonify, make_response, request
-from imaginate_api.extensions import fs
+import base64
+from bson import ObjectId
+from flask import Blueprint, jsonify, make_response, render_template, request
+from imaginate_api.extensions import fs, db
 from image_handler_client.schemas.image_info import ImageStatus
 from imaginate_api.utils import (
   validate_id,
@@ -92,3 +94,33 @@ def delete_image(id):
   info = build_result(res._id, res_real, res_date, res_theme, res_status, res_filename)
   fs.delete(res._id)
   return jsonify(info)
+
+#Image Verification Routes
+
+@bp.route("/verification-portal", methods=["GET"])
+def verification_portal():
+    obj = db['fs.files'].find_one({'status': ImageStatus.UNVERIFIED.value})
+    print(obj)
+    if obj:
+        grid_out = fs.find_one({"_id":obj['_id']})
+        data = grid_out.read()
+        base64_data = base64.b64encode(data).decode('ascii')
+        return render_template('verification_portal.html', id=obj['_id'], img_found=True, img_src=base64_data, obj_data=obj)
+    return render_template('verification_portal.html', img_found=False)
+
+@bp.route("/update-status", methods=["POST"])
+def update_status():
+    status = request.form['status']
+    if status:
+        query_filter = { '_id': ObjectId(request.form['_id']) }
+        update_operation = { "$set" : { "status" : status } }
+        db['fs.files'].find_one_and_update(query_filter, update_operation)
+    else:
+        return "new status not recieved",400  
+    return "status updated",200
+
+@bp.route("/delete_rejected", methods=["DELETE"])
+def delete_rejected():
+    filter = {"status":"rejected"}
+    results = db["fs.files"].delete_many(filter)
+    return results, 200

--- a/imaginate_api/templates/verification_portal.html
+++ b/imaginate_api/templates/verification_portal.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Imaginate Verification</title>
+    <script>
+        function submitForm(event) {
+            event.preventDefault();
+            const form = event.target;
+            const formData = new FormData(form);
+
+            fetch(form.action, {
+                method: form.method,
+                body: formData,
+            }).then(response => {
+                window.location.reload()
+            }).catch(error => {
+                console.error('Error:', error);
+            });
+        }
+    </script>
+</head>
+<body>
+  {% if img_found %}
+  <img src="data:image/png;base64,{{img_src}}" id="imgslot" height="500px"/>
+  <form action="/image/update-status" method="POST" enctype="multipart/form-data" onsubmit="submitForm(event)">
+    <input type="hidden" name="id" value="{{id}}">
+    <fieldset>
+      <legend>Is this image good enough?</legend> 
+      <div>
+        <input type="radio" id="verify" name="status" value="verified" checked />
+        <label for="verify">verify</label>
+      </div>
+      <div>
+        <input type="radio" id="reject" name="status" value="rejected" />
+        <label for="reject">reject</label>
+      </div>
+    </fieldset>    
+    <button type="submit">Submit</button>
+  </form>
+  <p>{{obj_data}}</p>
+  {% else %}
+  <p>no images needing verification found</p>
+  {% endif %}
+</body>
+</html>

--- a/imaginate_api/templates/verification_portal.html
+++ b/imaginate_api/templates/verification_portal.html
@@ -5,20 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Imaginate Verification</title>
     <script>
-        function submitForm(event) {
-            event.preventDefault();
-            const form = event.target;
-            const formData = new FormData(form);
+      function submitForm(event) {
+        event.preventDefault();
+        const form = event.target;
+        const formData = new FormData(form);
 
-            fetch(form.action, {
-                method: form.method,
-                body: formData,
-            }).then(response => {
-                window.location.reload()
-            }).catch(error => {
-                console.error('Error:', error);
-            });
-        }
+        fetch(form.action, {
+          method: form.method,
+          body: formData,
+        }).then(response => {
+          window.location.reload()
+        }).catch(error => {
+          console.error('Error:', error);
+        });
+      }
     </script>
 </head>
 <body>
@@ -39,7 +39,6 @@
     </fieldset>    
     <button type="submit">Submit</button>
   </form>
-  <p>{{obj_data}}</p>
   {% else %}
   <p>no images needing verification found</p>
   {% endif %}

--- a/imaginate_api/templates/verification_portal.html
+++ b/imaginate_api/templates/verification_portal.html
@@ -1,46 +1,58 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Imaginate Verification</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Imaginate Verification</title>
     <script>
       function submitForm(event) {
         event.preventDefault();
         const form = event.target;
         const formData = new FormData(form);
-
         fetch(form.action, {
           method: form.method,
           body: formData,
-        }).then(response => {
-          window.location.reload()
-        }).catch(error => {
-          console.error('Error:', error);
-        });
+        })
+          .then((response) => {
+            window.location.reload();
+          })
+          .catch((error) => {
+            console.error("Error:", error);
+          });
       }
     </script>
-</head>
-<body>
-  {% if img_found %}
-  <img src="data:image/png;base64,{{img_src}}" id="imgslot" height="500px"/>
-  <form action="/image/update-status" method="POST" enctype="multipart/form-data" onsubmit="submitForm(event)">
-    <input type="hidden" name="id" value="{{id}}">
-    <fieldset>
-      <legend>Is this image good enough?</legend> 
-      <div>
-        <input type="radio" id="verify" name="status" value="verified" checked />
-        <label for="verify">verify</label>
-      </div>
-      <div>
-        <input type="radio" id="reject" name="status" value="rejected" />
-        <label for="reject">reject</label>
-      </div>
-    </fieldset>    
-    <button type="submit">Submit</button>
-  </form>
-  {% else %}
-  <p>no images needing verification found</p>
-  {% endif %}
-</body>
+  </head>
+  <body>
+    {% if img_found %}
+    <img src="data:image/png;base64,{{img_src}}" id="imgslot" height="500px" />
+    <form
+      action="/image/update-status"
+      method="POST"
+      enctype="multipart/form-data"
+      onsubmit="submitForm(event)"
+    >
+      <input type="hidden" name="_id" value="{{id}}" />
+      <fieldset>
+        <legend>Is this image good enough?</legend>
+        <div>
+          <input
+            type="radio"
+            id="verify"
+            name="status"
+            value="verified"
+            checked
+          />
+          <label for="verify">verify</label>
+        </div>
+        <div>
+          <input type="radio" id="reject" name="status" value="rejected" />
+          <label for="reject">reject</label>
+        </div>
+      </fieldset>
+      <button type="submit">Submit</button>
+    </form>
+    {% else %}
+    <p>no images needing verification found</p>
+    {% endif %}
+  </body>
 </html>


### PR DESCRIPTION
### Added
- GET endpoint that returns image verification portal
- POST endpoint that updates an images status
- DELETE endpoint that deletes all images with the rejected status

### Screenshots
![image](https://github.com/zachale/imaginate-api/assets/47370318/4fe60d31-1131-4688-8b7c-a6896bd29dad)
