### PR TITLE
Implement GitHub actions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,83 @@
+name: PR Pipeline
+on: [pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Restore cached .venv
+        uses: actions/cache/restore@v4
+        id: cache-venv
+        with:
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          path: .venv
+      - name: Setup environment
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry config --list
+      - name: Install dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      - name: Cache .venv
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          path: .venv
+  test:
+    name: Test
+    needs: [build]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Restore cached .venv
+        uses: actions/cache/restore@v4
+        with:
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          path: .venv
+      - name: Test setup
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          pip install pytest
+      - name: Create .env
+        uses: SpicyPizza/create-envfile@v2.0
+        with:
+          envkey_DEV: "dev"
+          envkey_MONGO_TOKEN: ${{ secrets.MONGO_TOKEN }}
+          file_name: .env
+      - name: Run tests
+        run: poetry run pytest --doctest-modules --junitxml=junit/test-results.xml
+  lint:
+    name: Lint
+    needs: [build]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Restore cached .venv
+        uses: actions/cache/restore@v4
+        with:
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          path: .venv
+      - name: Lint setup
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run linter
+        run: ruff check --output-format=github .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-venv
+.venv
 .env
+*.env
 **/__pycache__
 .pytest_cache
 .ruff_cache
+junit

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@
 - Leaving the environment: `exit`
 - Installing libraries in the environment: `make install`
 - Run the Flask application: `python imaginate_api/app.py`
+- Encode / Decode .env via Bash: `cat decoded.env | base64 -w 0 > encoded.env` / `cat encoded.env | base64 --decode > decoded.env`
+  - We could use this in the future for .env variables in our GitHub actions workflow; though we need to make sure .env is encoded as `utf-8` file or we will run into errors    

--- a/imaginate_api/config.py
+++ b/imaginate_api/config.py
@@ -4,20 +4,20 @@ import sys
 
 
 VALID_ENVS = ["dev", "prod"]
+
+
 def get_db_env():
-    env = os.getenv("ENV")
-    if not env:
-        env = "dev" # Default to dev environment
-    elif env.lower() not in VALID_ENVS:
-        print(f"Environment should be one of: {VALID_ENVS}", file=sys.stderr)
-        sys.exit(1)
-    return env.lower()
+  env = os.getenv("ENV")
+  if not env:
+    env = "dev"  # Default to dev environment
+  elif env.lower() not in VALID_ENVS:
+    print(f"Environment should be one of: {VALID_ENVS}", file=sys.stderr)
+    sys.exit(1)
+  return env.lower()
 
 
 class Config:
-    def __init__(self):
-        load_dotenv()
-
-    MONGO_TOKEN = os.getenv("MONGO_TOKEN")
-    DB_ENV = get_db_env()
-    TESTING = False
+  load_dotenv()
+  MONGO_TOKEN = os.getenv("MONGO_TOKEN")
+  DB_ENV = get_db_env()
+  TESTING = False

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true


### PR DESCRIPTION
Under this description you will see GitHub actions at work!

EDIT: A quick note... The whole point of mocking is to avoid creating any sort of connection with MongoDB... while this is true for our standalone unit tests, it is not necessarily true when the Python script is invoked. A module import that leads to `imaginate_api.extensions` will cause `connect_mongodb` to be called, hence creating a connection. The solution? I honestly don't know, as the code will always run during module import, which I believe is impossible to mock unless it can be done above the import in some way