### PR TITLE
27 Update POST image/create endpoint

### DIFF
--- a/examples/create_image.py
+++ b/examples/create_image.py
@@ -1,0 +1,58 @@
+import requests
+import mimetypes
+from imaginate_api.schemas.image_info import ImageStatus
+import os
+from dotenv import load_dotenv
+
+# Quick script to test our POST image/create endpoint
+# See also imaginate_api/templates/index.html for other ways to call the same endpoint
+load_dotenv()
+
+# First type of call (via bytes)
+IMAGE = "examples/images/pokemon.png"
+URL = "http://127.0.0.1:5000/image/create"
+MIME = mimetypes.guess_type(IMAGE)
+PEXELS_BASE_URL = "https://api.pexels.com/v1"
+
+if not MIME:
+  print("Could not guess file type")
+  exit(1)
+files = {"file": (IMAGE.split("/")[-1], open(IMAGE, "rb"), MIME[0])}
+response = requests.post(
+  URL,
+  {"real": True, "date": 1, "theme": "pokemon", "status": ImageStatus.UNVERIFIED.value},
+  files=files,
+)
+if response.ok:
+  print(f"Endpoint returned: {response.json()}")
+else:
+  print(f"Endpoint returned: {response.status_code}")
+
+# Second type of call (via Pexels)
+QUERY = "pokemon"
+TOTAL_RESULTS = 1  # Max per page is 80: https://www.pexels.com/api/documentation/#photos-search__parameters__per_page
+response = requests.get(
+  f"{PEXELS_BASE_URL}/search",
+  params={"query": QUERY, "per_page": TOTAL_RESULTS},
+  headers={"Authorization": os.getenv("PEXELS_TOKEN")},
+)
+response_data = response.json()
+if TOTAL_RESULTS > response_data["total_results"]:
+  print(f"Requested {TOTAL_RESULTS} > Total {response_data['total_results']}")
+photos_data = response_data["photos"]
+for photo in photos_data:
+  response = requests.post(
+    URL,
+    {
+      "url": photo["src"]["original"],
+      "real": True,
+      "date": 1,
+      "theme": "pokemon",
+      "status": ImageStatus.UNVERIFIED.value,
+    },
+    files=files,
+  )
+  if response.ok:
+    print(f"Endpoint returned: {response.json()}")
+  else:
+    print(f"Endpoint returned: {response.status_code}")

--- a/imaginate_api/config.py
+++ b/imaginate_api/config.py
@@ -19,5 +19,6 @@ def get_db_env():
 class Config:
   load_dotenv()
   MONGO_TOKEN = os.getenv("MONGO_TOKEN")
+  PEXELS_TOKEN = os.getenv("PEXELS_TOKEN")
   DB_ENV = get_db_env()
   TESTING = False

--- a/imaginate_api/date/routes.py
+++ b/imaginate_api/date/routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, abort, jsonify
-from extensions import fs
-from utils import build_result
+from imaginate_api.extensions import fs
+from imaginate_api.utils import build_result
 from http import HTTPStatus
 
 bp = Blueprint("date", __name__)
@@ -24,6 +24,7 @@ def images_by_date(day):
         document.date,
         document.theme,
         document.status,
+        document.filename,
       )
     )
   return jsonify(out)

--- a/imaginate_api/templates/index.html
+++ b/imaginate_api/templates/index.html
@@ -5,24 +5,44 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Imaginate</title>
 </head>
-<body>
-  <form action="/create" method="post" enctype="multipart/form-data">
-    <label for="file">Choose file:</label>
-    <input type="file" name="file">
-    <br><br>
-    <label for="real">Real image:</label>
-    <select name="real" id="real">
-      <option value="true">True</option>
-      <option value="false">False</option>
-    </select>
-    <br><br>
-    <label for="date">Date:</label>
-    <input type="number" id="date" name="date" min="1">
-    <br><br>
-    <label for="theme">Theme:</label>
-    <input type="text" id="theme" name="theme">
-    <br><br>
-    <input type="submit" value="submit">
-  </form>
+<body style="margin: 0; padding: 0;">
+  <div style="display: flex; width: 100%; height: 100vh; align-items: center; justify-content: space-around;">
+    <form action="/image/create" method="post" enctype="multipart/form-data">
+      <label for="file">Choose file:</label>
+      <input type="file" name="file">
+      <br><br>
+      <label for="real">Real image:</label>
+      <select name="real" id="real">
+        <option value="true">True</option>
+        <option value="false">False</option>
+      </select>
+      <br><br>
+      <label for="date">Date:</label>
+      <input type="number" id="date" name="date" min="1">
+      <br><br>
+      <label for="theme">Theme:</label>
+      <input type="text" id="theme" name="theme">
+      <br><br>
+      <input type="submit" value="submit">
+    </form>
+    <form action="/image/create" method="post" enctype="multipart/form-data">
+      <label for="url">URL:</label>
+      <input type="text" id="url" name="url">
+      <br><br>
+      <label for="real">Real image:</label>
+      <select name="real" id="real">
+        <option value="true">True</option>
+        <option value="false">False</option>
+      </select>
+      <br><br>
+      <label for="date">Date:</label>
+      <input type="number" id="date" name="date" min="1">
+      <br><br>
+      <label for="theme">Theme:</label>
+      <input type="text" id="theme" name="theme">
+      <br><br>
+      <input type="submit" value="submit">
+    </form>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Closes https://github.com/imaginate-ai/imaginate-api/issues/27

See examples folder for a call via script. You can also call the same endpoint using the forms provided on the root URL (i.e. /) of the application. The attribute url determines which method is used to upload a file to the database (i.e. url vs. file). NOTE: There may (100% are) be security issues linked to this endpoint as we allow the user to choose any URL of their choice; essentially allowing any sort of data to be uploaded to the database. Though, since this endpoint is intended for personal usage I believe it is fine.