### PR TITLE
Create image verification portal #8

### DIFF
--- a/imaginate_api/app.py
+++ b/imaginate_api/app.py
@@ -4,6 +4,9 @@ from imaginate_api.date.routes import bp as date_routes
 from imaginate_api.image.routes import bp as image_routes
 from imaginate_api.config import Config
 
+# Constants
+from schemas.image_info import ImageStatus
+
 
 def create_app():
   app = Flask(__name__)

--- a/imaginate_api/templates/verification_portal.html
+++ b/imaginate_api/templates/verification_portal.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Imaginate Verification</title>
+    <script>
+        function submitForm(event) {
+            event.preventDefault();
+            const form = event.target;
+            const formData = new FormData(form);
+
+            fetch(form.action, {
+                method: form.method,
+                body: formData,
+            }).then(response => {
+                window.location.reload()
+            }).catch(error => {
+                console.error('Error:', error);
+            });
+        }
+    </script>
+</head>
+<body>
+  {% if img_found %}
+  <img src="data:image/png;base64,{{img_src}}" id="imgslot" height="500px"/>
+  <form action="/image/update-status" method="POST" enctype="multipart/form-data" onsubmit="submitForm(event)">
+    <input type="hidden" name="id" value="{{id}}">
+    <fieldset>
+      <legend>Is this image good enough?</legend> 
+      <div>
+        <input type="radio" id="verify" name="status" value="verified" checked />
+        <label for="verify">verify</label>
+      </div>
+      <div>
+        <input type="radio" id="reject" name="status" value="rejected" />
+        <label for="reject">reject</label>
+      </div>
+    </fieldset>    
+    <button type="submit">Submit</button>
+  </form>
+  <p>{{obj_data}}</p>
+  {% else %}
+  <p>no images needing verification found</p>
+  {% endif %}
+</body>
+</html>

--- a/imaginate_api/templates/verification_portal.html
+++ b/imaginate_api/templates/verification_portal.html
@@ -5,20 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Imaginate Verification</title>
     <script>
-        function submitForm(event) {
-            event.preventDefault();
-            const form = event.target;
-            const formData = new FormData(form);
+      function submitForm(event) {
+        event.preventDefault();
+        const form = event.target;
+        const formData = new FormData(form);
 
-            fetch(form.action, {
-                method: form.method,
-                body: formData,
-            }).then(response => {
-                window.location.reload()
-            }).catch(error => {
-                console.error('Error:', error);
-            });
-        }
+        fetch(form.action, {
+          method: form.method,
+          body: formData,
+        }).then(response => {
+          window.location.reload()
+        }).catch(error => {
+          console.error('Error:', error);
+        });
+      }
     </script>
 </head>
 <body>
@@ -39,7 +39,6 @@
     </fieldset>    
     <button type="submit">Submit</button>
   </form>
-  <p>{{obj_data}}</p>
   {% else %}
   <p>no images needing verification found</p>
   {% endif %}


### PR DESCRIPTION
### Added
- GET endpoint that returns image verification portal
- POST endpoint that updates an images status
- DELETE endpoint that deletes all images with the rejected status

### Screenshots
![image](https://github.com/zachale/imaginate-api/assets/47370318/4fe60d31-1131-4688-8b7c-a6896bd29dad)
